### PR TITLE
prepend middleware instead of append

### DIFF
--- a/src/Providers/CloudflareSupportServiceProvider.php
+++ b/src/Providers/CloudflareSupportServiceProvider.php
@@ -22,7 +22,7 @@ class CloudflareSupportServiceProvider extends BasePluginServiceProvider
      */
     public function register()
     {
-        $this->registerMiddlewares();
+        $this->middleware($this->middleware, true);
     }
 
     /**


### PR DESCRIPTION
Some other plugin may want to register some middleware. CloudflareSupport middleware should be registered at the very first step to allow others middleware to corretcly retrive IP address 